### PR TITLE
fix: use random port for desktop/standalone builds to avoid port conflicts

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -1,6 +1,8 @@
 import argparse
 import enum
 import os
+import socket
+import sys
 import comfy.options
 
 
@@ -36,7 +38,7 @@ class EnumAction(argparse.Action):
 parser = argparse.ArgumentParser()
 
 parser.add_argument("--listen", type=str, default="127.0.0.1", metavar="IP", nargs="?", const="0.0.0.0,::", help="Specify the IP address to listen on (default: 127.0.0.1). You can give a list of ip addresses by separating them with a comma like: 127.2.2.2,127.3.3.3 If --listen is provided without an argument, it defaults to 0.0.0.0,:: (listens on all ipv4 and ipv6)")
-parser.add_argument("--port", type=int, default=8188, help="Set the listen port.")
+parser.add_argument("--port", type=int, default=8188, help="Set the listen port. Use 0 for a random available port (useful for desktop apps).")
 parser.add_argument("--tls-keyfile", type=str, help="Path to TLS (SSL) key file. Enables TLS, makes app accessible at https://... requires --tls-certfile to function")
 parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function")
 parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
@@ -220,6 +222,13 @@ else:
 
 if args.windows_standalone_build:
     args.auto_launch = True
+    if args.port != 0:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(('', args.port))
+            sock.close()
+        except OSError:
+            args.port = 0
 
 if args.disable_auto_launch:
     args.auto_launch = False

--- a/server.py
+++ b/server.py
@@ -943,6 +943,11 @@ class PromptServer():
             port = addr[1]
             site = web.TCPSite(runner, address, port, ssl_context=ssl_ctx)
             await site.start()
+            
+            if port == 0 and site._server and site._server.sockets:
+                port = site._server.sockets[0].getsockname()[1]
+                if verbose:
+                    logging.info("Random port assigned: {}".format(port))
 
             if not hasattr(self, 'address'):
                 self.address = address #TODO: remove this

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -160,3 +160,28 @@ def test_base_path_change_clears_old(set_base_dir):
 
     for name in ["controlnet", "diffusion_models", "text_encoders"]:
         assert len(folder_paths.get_folder_paths(name)) == 2
+
+
+def test_windows_standalone_random_port():
+    """Test that --windows-standalone-build uses port 0 when port is in use"""
+    import socket
+    
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('', 8188))
+    try:
+        with patch.object(sys, 'argv', ["main.py", "--windows-standalone-build"]):
+            reload(comfy.cli_args)
+            assert comfy.cli_args.args.port == 0
+            assert comfy.cli_args.args.windows_standalone_build
+    finally:
+        sock.close()
+    
+    with patch.object(sys, 'argv', ["main.py", "--windows-standalone-build", "--port", "9999"]):
+        reload(comfy.cli_args)
+        assert comfy.cli_args.args.port == 9999 or comfy.cli_args.args.port == 0
+        assert comfy.cli_args.args.windows_standalone_build
+    
+    with patch.object(sys, 'argv', ["main.py"]):
+        reload(comfy.cli_args)
+        assert comfy.cli_args.args.port == 8188
+        assert not comfy.cli_args.args.windows_standalone_build


### PR DESCRIPTION
> ### Fix: Use random port for desktop/standalone builds to avoid conflicts

## Problem

The desktop app encounters port conflicts when other services (like Docker) are using various ports.
This causes issues for users who have services running on the same port that ComfyUI tries to use.

<img src="https://github.com/user-attachments/assets/9ba76770-cf1e-4a66-accb-33d93cde9015" alt="port conflict" width="300" />

> The image demonstrates that Firebase's auth simulator is showing up on port 8000 within the comfy app wrapper.

### Solution

This PR modifies the port assignment for standalone builds to detect port conflicts and automatically use port 0 (random port allocation by the OS) when the requested port is already in use. This ensures the desktop app will always get an available port without conflicts.

## Changes

1. `comfy/cli_args.py`: When --windows-standalone-build flag is used, check if the requested port is available. If not, automatically switch to port 0 (random port)
1. `server.py`: Detect when port 0 is used, retrieve the actual assigned port from the socket, and log it for the desktop app to parse
1. `tests-unit/comfy_test/folder_path_test.py`: Adds test coverage for the new behavior

 ### Code Changes

cli_args.py:
```python
if args.windows_standalone_build:
  args.auto_launch = True
  if args.port != 0:
    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    try:
      sock.bind(('', args.port))
      sock.close()
    except OSError:
      args.port = 0
```

server.py:
```python
 if port == 0 and site._server and site._server.sockets:
   port = site._server.sockets[0].getsockname()[1]
   if verbose:
     logging.info("Random port assigned: {}".format(port))
```

## Testing

> Tested on macOS M4 with Docker running on port 8000. 

The issue and fix can be demonstrated using these Dockerfiles:
 
- [Shows the issue with fixed port](https://github.com/yowainwright/ComfyUI/blob/dockerfiles-fix-electron-port-demo/Dockerfile.master)
- [Shows the fix with random port allocation](https://github.com/yowainwright/ComfyUI/blob/dockerfiles-fix-electron-port-demo/Dockerfile.fix)

Test results:

  - Port 8000 conflict: Confirmed when Docker or other services use port 8000
  - With fix: ComfyUI successfully starts on a random available port
  - Desktop app can parse the actual port from the log output

## Backwards Compatibility

 - Default behavior unchanged (port 8188 for regular usage)
 - Only affects Windows standalone builds
 - Explicit --port flag still respected if provided